### PR TITLE
Missing import sys.

### DIFF
--- a/clearempty.py
+++ b/clearempty.py
@@ -13,6 +13,7 @@
 
 import subprocess
 import argparse
+import sys
 from collections import defaultdict
 
 parser = argparse.ArgumentParser(description='Removes empty auto snapshots.')


### PR DESCRIPTION
If you mistype a dataset, a NameError is raised as the sys module is not imported.