### PR TITLE
Change snap-strip's `--dryrun` to `--test`

### DIFF
--- a/snap-strip.py
+++ b/snap-strip.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 
 parser = argparse.ArgumentParser(description='Removes empty auto snapshots.')
 parser.add_argument('datasets', nargs='+', help='the root dataset(s) from which to remove snapshots')
-parser.add_argument('--dryrun', '-n', action="store_true", default=False, help='only display the snapshots that would be deleted, without actually deleting them. Note that due to dependencies between snapshots, this may not match what would really happen.')
+parser.add_argument('--test', '-t', action="store_true", default=False, help='only display the snapshots that would be deleted, without actually deleting them. Note that due to dependencies between snapshots, this may not match what would really happen.')
 parser.add_argument('--verbose', '-v', action="store_true", default=False, help='be verbose about what snapshots will be deleted and how much space will be freed.')
 parser.add_argument('--recursive', '-r', action="store_true", default=False, help='recursively removes snapshots from nested datasets')
 parser.add_argument('--prefix', '-p', action='append', help='list of snapshot name prefixes that will be considered')


### PR DESCRIPTION
The script is broken otherwise, and this clearly matches the convention in the rest of the scripts.